### PR TITLE
Fix #1 nameerror bin not found

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -108,11 +108,6 @@ SelfAssignment:
 SignalException:
   Enabled: false
 
-# Offense count: 53
-# Cop supports --auto-correct.
-SingleSpaceBeforeFirstArg:
-  Enabled: false
-
 SpaceAroundOperators:
   Enabled: false
 
@@ -302,10 +297,6 @@ Style/NumericLiterals:
   Enabled: false
 
 Metrics/ParameterLists:
-  Enabled: false
-
-Style/TrailingComma:
-  # EnforcedStyleForMultiline: comma
   Enabled: false
 
 Metrics/CyclomaticComplexity:

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,6 @@ group :development, :test do
   gem "rake", "~> 10.4"
   gem "rspec", "~> 3.0"
   gem "rspec-mocks", "~> 3.0"
-  gem "rubocop", "~> 0.24"
+  gem "rubocop", "~> 0.36"
   gem "rubygems-tasks", "~> 0.2"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,12 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :development, :test do
+  gem "bundler", "~> 1.7"
+  gem "rake", "~> 10.4"
+  gem "rspec", "~> 3.0"
+  gem "rspec-mocks", "~> 3.0"
+  gem "rubocop", "~> 0.24"
+  gem "rubygems-tasks", "~> 0.2"
+end

--- a/lib/lowered/expectations.rb
+++ b/lib/lowered/expectations.rb
@@ -33,7 +33,7 @@ class LoweredExpectations
         return exe if File.executable?(exe) && !File.directory?(exe)
       end
     end
-    raise MissingExecutableError.new("#{executable} not found in #{ENV['PATH']}")
+    raise MissingExecutableError.new("#{cmd} not found in #{ENV['PATH']}")
   end
 
   def self.verify_version(version, pattern)

--- a/lib/lowered/expectations.rb
+++ b/lib/lowered/expectations.rb
@@ -5,7 +5,7 @@ require 'shellwords'
 require 'pty'
 
 class LoweredExpectations
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'.freeze
 
   class VersionPatternError < StandardError
   end
@@ -54,7 +54,7 @@ class LoweredExpectations
         while !r.eof?
           c = r.getc
           stdout << c
-          $stdout.write "#{c}"
+          $stdout.write c.to_s
         end
         Process.wait(pid)
       end

--- a/lowered-expectations.gemspec
+++ b/lowered-expectations.gemspec
@@ -26,11 +26,4 @@ END
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.4"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rspec-mocks", "~> 3.0"
-  spec.add_development_dependency "rubocop", "~> 0.24"
-  spec.add_development_dependency "rubygems-tasks", "~> 0.2"
 end

--- a/spec/integration/lowered/expectations_integration_spec.rb
+++ b/spec/integration/lowered/expectations_integration_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe LoweredExpectations do
 
   describe '.which' do
     it 'returns true when the executable is on the PATH' do
-      expect(LoweredExpectations.which tool).to be_truthy
+      expect(LoweredExpectations.which(tool)).to be_truthy
     end
 
     it 'raises an error when the executable is not on the PATH' do

--- a/spec/integration/lowered/expectations_integration_spec.rb
+++ b/spec/integration/lowered/expectations_integration_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe LoweredExpectations do
     end
 
     it 'raises an error when the executable is not on the PATH' do
-      expect{LoweredExpectations.which 'sometoolthatdoesnotexist'}.to raise_error
+      expect{LoweredExpectations.which 'sometoolthatdoesnotexist'}.to raise_error(LoweredExpectations::MissingExecutableError)
     end
   end
 end

--- a/spec/lowered/expectations_spec.rb
+++ b/spec/lowered/expectations_spec.rb
@@ -44,7 +44,7 @@ Features: AsynchDNS GSS-Negotiate IPv6 Largefile NTLM NTLM_WB SSL lib"
 
   describe '.which' do
     it 'returns true when the executable is on the PATH' do
-      expect(LoweredExpectations.which tool).to be_truthy
+      expect(LoweredExpectations.which(tool)).to be_truthy
     end
 
     it 'raises an error when the executable is not on the PATH' do
@@ -54,12 +54,12 @@ Features: AsynchDNS GSS-Negotiate IPv6 Largefile NTLM NTLM_WB SSL lib"
 
   describe '.verify_version' do
     it 'returns true when the version string matches the version pattern' do
-      expect(LoweredExpectations.verify_version version, '~> 0.1').to        be_truthy
-      expect(LoweredExpectations.verify_version version, '~> 0').to          be_truthy
-      expect(LoweredExpectations.verify_version version, '> 0.1.1').to       be_truthy
-      expect(LoweredExpectations.verify_version version, '< 1').to           be_truthy
-      expect(LoweredExpectations.verify_version version, '> 0').to           be_truthy
-      expect(LoweredExpectations.verify_version version, "= #{version}").to  be_truthy
+      expect(LoweredExpectations.verify_version(version, '~> 0.1')).to        be_truthy
+      expect(LoweredExpectations.verify_version(version, '~> 0')).to          be_truthy
+      expect(LoweredExpectations.verify_version(version, '> 0.1.1')).to       be_truthy
+      expect(LoweredExpectations.verify_version(version, '< 1')).to           be_truthy
+      expect(LoweredExpectations.verify_version(version, '> 0')).to           be_truthy
+      expect(LoweredExpectations.verify_version(version, "= #{version}")).to  be_truthy
     end
 
     it 'raise an error when the version string does not match the version pattern' do

--- a/spec/lowered/expectations_spec.rb
+++ b/spec/lowered/expectations_spec.rb
@@ -48,7 +48,7 @@ Features: AsynchDNS GSS-Negotiate IPv6 Largefile NTLM NTLM_WB SSL lib"
     end
 
     it 'raises an error when the executable is not on the PATH' do
-      expect{LoweredExpectations.which 'sometoolthatdoesnotexist'}.to raise_error
+      expect{LoweredExpectations.which 'sometoolthatdoesnotexist'}.to raise_error(LoweredExpectations::MissingExecutableError)
     end
   end
 


### PR DESCRIPTION
- move development dependencies out of the gemspec into the gemfile
- fix spec and integration tests to look for specific raised error for `.which` method.
- Resolve `NameError` raise on checking path to see if cmd exists.