### PR TITLE
Fix exit status check in #run!

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,9 @@
 # lowered-expectations Release Notes
 
+## 1.0.3
+
+* Bugfix for exitstatus checks when running in quiet mode
+
 ## 1.0.2
 
 * Updated rubocop library to cover CVE-2017-8418

--- a/lib/lowered/expectations.rb
+++ b/lib/lowered/expectations.rb
@@ -48,6 +48,7 @@ class LoweredExpectations
     if quiet
       # Run without streaming std* to any screen
       stdout, stderr, status = Open3.capture3(cmd)
+      status = status.exitstatus
     else
       # Run but stream as well as capture stdout to the screen
       status = pty(cmd) do |r,w,pid|

--- a/lib/lowered/expectations.rb
+++ b/lib/lowered/expectations.rb
@@ -4,7 +4,7 @@ require 'shellwords'
 require 'pty'
 
 class LoweredExpectations
-  VERSION = '1.0.2'.freeze
+  VERSION = '1.0.3'.freeze
 
   class VersionPatternError < StandardError
   end

--- a/spec/integration/lowered/expectations_integration_spec.rb
+++ b/spec/integration/lowered/expectations_integration_spec.rb
@@ -26,4 +26,26 @@ RSpec.describe LoweredExpectations do
       expect{LoweredExpectations.which 'sometoolthatdoesnotexist'}.to raise_error(LoweredExpectations::MissingExecutableError)
     end
   end
+
+  describe '.run!' do
+    let(:tool_path) { LoweredExpectations.which(tool) }
+    let(:tool_output) { `#{tool_path} --version` }
+    it 'returns stdout' do
+      expect(LoweredExpectations.send('run!', tool, '--version').delete("\r")).to eq tool_output
+    end
+
+    it 'returns stdout in quiet mode' do
+      expect(LoweredExpectations.send('run!', tool, '--version', quiet: true).delete("\r")).to eq tool_output
+    end
+
+    it 'raises an error when the executable returns non-zero' do
+      expect{LoweredExpectations.send('run!', tool, '--versssion')}
+        .to raise_error(LoweredExpectations::CommandExecutionError)
+    end
+
+    it 'raises an error when the executable returns non-zero in quiet mode' do
+      expect{LoweredExpectations.send('run!', tool, '--versssion', quiet: true)}
+        .to raise_error(LoweredExpectations::CommandExecutionError)
+    end
+  end
 end


### PR DESCRIPTION
`#zero?` only works on integers.  `Open3`'s status is a
`Process::Status` object and surfaces a `NoMethodError`
when you try to call `#zero?` on it.

So assign `status.exitstatus` to the `status` variable during the
`quiet` run operation.

Wrote a few tests that will verify this continues working in the future